### PR TITLE
Fix #406: Prevent multiple server sessions at startup

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -166,7 +166,7 @@ export async function activate(context: ExtensionContext) {
 
 	// Resolve the ServerSpec for a document or workspace folder URI, prompting
 	// for a missing password via the Server Manager's authentication provider.
-	const resolveServerSpec = async (uriObj: Uri): Promise<ServerSpec> => {
+	async function resolveServerSpec(uriObj: Uri): Promise<ServerSpec> {
 		const wsFolderUriString = workspace.getWorkspaceFolder(uriObj)?.uri.toString();
 		const serverSpec = objectScriptApi.serverForUri(uriObj);
 		if (
@@ -223,6 +223,18 @@ export async function activate(context: ExtensionContext) {
 		}
 		return serverSpec;
 	};
+
+	// Ensure that every server has at most one session.
+	for (const f of workspace.workspaceFolders ?? []) {
+		try {
+			const serverSpec = await resolveServerSpec(f.uri);
+			if (serverSpec.active) {
+				await makeRESTRequest("HEAD", 1, "", serverSpec);
+			}
+		} catch {
+			// Ignore any failure; the session will be created on demand instead
+		}
+	}
 
 	const textDecoder = new TextDecoder();
 	context.subscriptions.push(
@@ -285,12 +297,12 @@ export async function activate(context: ExtensionContext) {
 								: uri.path.split("/").slice(1).join(".");
 						const docParams =
 							params.server.apiVersion >= 4 &&
-							workspace
-								.getConfiguration(
-									"objectscript",
-									workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
-								)
-								.get<boolean>("multilineMethodArgs")
+								workspace
+									.getConfiguration(
+										"objectscript",
+										workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
+									)
+									.get<boolean>("multilineMethodArgs")
 								? { format: "udl-multiline" }
 								: undefined;
 						const resp = await makeRESTRequest(
@@ -331,17 +343,6 @@ export async function activate(context: ExtensionContext) {
 
 	// Start the client. This will also launch the server
 	await client.start();
-
-	// Ensure that every server has at most one session.
-	for (const f of workspace.workspaceFolders ?? []) {
-		try {
-			const serverSpec = await resolveServerSpec(f.uri);
-			if (!serverSpec.active || !serverSpec.apiVersion) continue;
-			await makeRESTRequest("GET", 1, "", serverSpec);
-		} catch {
-			// Ignore any failure; the session will be created on demand instead
-		}
-	}
 
 	const workbenchConfig = workspace.getConfiguration("workbench");
 	if (

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -39,14 +39,11 @@ export let client: LanguageClient;
 /**
  * Cache for cookies from REST requests to InterSystems servers.
  */
-const cookiesCache: Map<string, {
-	promise: Promise<string[]>,
-	resolve?: (value: string[]) => void,
-}> = new Map();
+const cookiesCache: Map<string, string[]> = new Map();
 
-export async function updateCookies(newCookies: string[], server: ServerSpec): Promise<string[]> {
+export function updateCookies(newCookies: string[], server: ServerSpec): string[] {
 	const key = `${server.username}@${server.host}:${server.port}${server.pathPrefix}`;
-	const cookies = await (cookiesCache.get(key)?.promise ?? emptyCookies());
+	const cookies = cookiesCache.get(key) ?? [];
 	newCookies.forEach((cookie) => {
 		const [cookieName] = cookie.split("=");
 		const index = cookies.findIndex((el) => el.startsWith(cookieName));
@@ -56,33 +53,12 @@ export async function updateCookies(newCookies: string[], server: ServerSpec): P
 			cookies.push(cookie);
 		}
 	});
-	const cache = cookiesCache.get(key);
-	if (cache && cache.resolve) {
-		cache.resolve(cookies)
-		delete cache.resolve
-	} else {
-		cookiesCache.set(key, { promise: new Promise((resolve) => resolve(cookies)) });
-	}
+	cookiesCache.set(key, cookies);
 	return cookies;
 }
 
-function emptyCookies(): Promise<string[]> {
-	return new Promise((resolve) => resolve([]))
-}
-
-// Each getCookies call MUST be accompanied by some calls to updateCookies
-export async function getCookies(server: ServerSpec): Promise<string[]> {
-	const key = `${server.username}@${server.host}:${server.port}${server.pathPrefix}`;
-	if (cookiesCache.has(key)) {
-		// A typical caller waits for the cookie promise to resolve.
-		return cookiesCache.get(key).promise
-	} else {
-		// The first caller for this key gets the empty cookies immediately.
-		let resolve: (value: string[]) => void;
-		const promise: Promise<string[]> = new Promise((r) => resolve = r);
-		cookiesCache.set(key, { promise, resolve })
-		return emptyCookies();
-	}
+export function getCookies(server: ServerSpec): string[] {
+	return cookiesCache.get(`${server.username}@${server.host}:${server.port}${server.pathPrefix}`) ?? [];
 }
 
 let objectScriptApi: any;
@@ -188,67 +164,70 @@ export async function activate(context: ExtensionContext) {
 		});
 	}
 
+	// Resolve the ServerSpec for a document or workspace folder URI, prompting
+	// for a missing password via the Server Manager's authentication provider.
+	const resolveServerSpec = async (uriObj: Uri): Promise<ServerSpec> => {
+		const wsFolderUriString = workspace.getWorkspaceFolder(uriObj)?.uri.toString();
+		const serverSpec = objectScriptApi.serverForUri(uriObj);
+		if (
+			// Server was resolved
+			serverSpec.host !== "" &&
+			// Connection isn't unauthenticated
+			serverSpec.username != undefined &&
+			serverSpec.username != "" &&
+			serverSpec.username.toLowerCase() != "unknownuser" &&
+			// A password is missing
+			typeof serverSpec.password === "undefined" &&
+			// A supported version of the Server Manager is installed
+			serverManagerExt != undefined &&
+			gt(serverManagerExt.packageJSON.version, "3.0.0")
+		) {
+			// The main extension didn't provide a password, so we must
+			// get it from the server manager's authentication provider.
+			const scopes = [serverSpec.serverName, serverSpec.username];
+			try {
+				const account = serverManagerApi?.getAccount
+					? serverManagerApi.getAccount({ name: serverSpec.serverName, ...serverSpec })
+					: undefined;
+				let session = await authentication.getSession(serverManager.AUTHENTICATION_PROVIDER, scopes, {
+					silent: true,
+					account,
+				});
+				if (!session) {
+					session = await authentication.getSession(serverManager.AUTHENTICATION_PROVIDER, scopes, {
+						createIfNone: true,
+						account,
+					});
+				}
+				if (session) {
+					serverSpec.username = session.scopes[1];
+					serverSpec.password = session.accessToken;
+				}
+			} catch (error) {
+				// The user did not consent to sharing authentication information
+				if (error instanceof Error) {
+					client.warn(`${serverManager.AUTHENTICATION_PROVIDER}: ${error.message}`);
+				}
+			}
+		}
+		if (
+			typeof serverSpec.username == "string" &&
+			serverSpec.username.toLowerCase() == "unknownuser" &&
+			typeof serverSpec.password == "undefined"
+		) {
+			// UnknownUser without a password means "unauthenticated"
+			serverSpec.username = undefined;
+		}
+		if (wsFolderUriString && !wsFolderServerSpecs.has(wsFolderUriString)) {
+			wsFolderServerSpecs.set(wsFolderUriString, serverSpec);
+		}
+		return serverSpec;
+	};
+
 	const textDecoder = new TextDecoder();
 	context.subscriptions.push(
 		// Register custom request handlers
-		client.onRequest("intersystems/server/resolveFromUri", async (uri: string) => {
-			const uriObj = Uri.parse(uri);
-			const wsFolderUriString = workspace.getWorkspaceFolder(uriObj)?.uri.toString();
-			const serverSpec = objectScriptApi.serverForUri(uriObj);
-			if (
-				// Server was resolved
-				serverSpec.host !== "" &&
-				// Connection isn't unauthenticated
-				serverSpec.username != undefined &&
-				serverSpec.username != "" &&
-				serverSpec.username.toLowerCase() != "unknownuser" &&
-				// A password is missing
-				typeof serverSpec.password === "undefined" &&
-				// A supported version of the Server Manager is installed
-				serverManagerExt != undefined &&
-				gt(serverManagerExt.packageJSON.version, "3.0.0")
-			) {
-				// The main extension didn't provide a password, so we must
-				// get it from the server manager's authentication provider.
-				const scopes = [serverSpec.serverName, serverSpec.username];
-				try {
-					const account = serverManagerApi?.getAccount
-						? serverManagerApi.getAccount({ name: serverSpec.serverName, ...serverSpec })
-						: undefined;
-					let session = await authentication.getSession(serverManager.AUTHENTICATION_PROVIDER, scopes, {
-						silent: true,
-						account,
-					});
-					if (!session) {
-						session = await authentication.getSession(serverManager.AUTHENTICATION_PROVIDER, scopes, {
-							createIfNone: true,
-							account,
-						});
-					}
-					if (session) {
-						serverSpec.username = session.scopes[1];
-						serverSpec.password = session.accessToken;
-					}
-				} catch (error) {
-					// The user did not consent to sharing authentication information
-					if (error instanceof Error) {
-						client.warn(`${serverManager.AUTHENTICATION_PROVIDER}: ${error.message}`);
-					}
-				}
-			}
-			if (
-				typeof serverSpec.username == "string" &&
-				serverSpec.username.toLowerCase() == "unknownuser" &&
-				typeof serverSpec.password == "undefined"
-			) {
-				// UnknownUser without a password means "unauthenticated"
-				serverSpec.username = undefined;
-			}
-			if (wsFolderUriString && !wsFolderServerSpecs.has(wsFolderUriString)) {
-				wsFolderServerSpecs.set(wsFolderUriString, serverSpec);
-			}
-			return serverSpec;
-		}),
+		client.onRequest("intersystems/server/resolveFromUri", (uri: string) => resolveServerSpec(Uri.parse(uri))),
 		client.onRequest("intersystems/uri/localToVirtual", (uri: string): string => {
 			const newuri: Uri = objectScriptApi.serverDocumentUriForUri(Uri.parse(uri));
 			return newuri.toString();
@@ -306,12 +285,12 @@ export async function activate(context: ExtensionContext) {
 								: uri.path.split("/").slice(1).join(".");
 						const docParams =
 							params.server.apiVersion >= 4 &&
-								workspace
-									.getConfiguration(
-										"objectscript",
-										workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
-									)
-									.get<boolean>("multilineMethodArgs")
+							workspace
+								.getConfiguration(
+									"objectscript",
+									workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
+								)
+								.get<boolean>("multilineMethodArgs")
 								? { format: "udl-multiline" }
 								: undefined;
 						const resp = await makeRESTRequest(
@@ -352,6 +331,21 @@ export async function activate(context: ExtensionContext) {
 
 	// Start the client. This will also launch the server
 	client.start();
+
+	// Establish one session with each server used by the workspace before
+	// activation completes. Since IntelliSense requests aren't sent until after
+	// activation finishes, they will all reuse these sessions rather than each
+	// creating a new one when many editor tabs are open at startup (#406).
+	for (const f of workspace.workspaceFolders ?? []) {
+		try {
+			const serverSpec = await resolveServerSpec(f.uri);
+			if (!serverSpec.active || !serverSpec.apiVersion) continue;
+			// A GET request authenticates and caches the session cookie
+			await makeRESTRequest("GET", 1, "", serverSpec);
+		} catch {
+			// Ignore any failure; the session will be created on demand instead
+		}
+	}
 
 	const workbenchConfig = workspace.getConfiguration("workbench");
 	if (
@@ -443,7 +437,7 @@ export async function deactivate(): Promise<void> {
 	for (const f of workspace.workspaceFolders ?? []) {
 		const serverSpec = wsFolderServerSpecs.get(f.uri.toString());
 		if (!serverSpec?.active) continue;
-		const sessionCookie = (await getCookies(serverSpec)).find((c) => c.startsWith("CSPSESSIONID-"));
+		const sessionCookie = getCookies(serverSpec).find((c) => c.startsWith("CSPSESSIONID-"));
 		if (!sessionCookie || loggedOut.has(sessionCookie)) continue;
 		loggedOut.add(sessionCookie);
 		promises.push(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -164,13 +164,8 @@ export async function activate(context: ExtensionContext) {
 		});
 	}
 
-<<<<<<< HEAD
 	// Resolve the ServerSpec for a document or workspace folder URI, prompting
 	// for a missing password via the Server Manager's authentication provider.
-=======
-	// Resolve the ServerSpec for a document or workspace folder URI, prompting for
-	// a missing password via the Server Manager's authentication provider.
->>>>>>> 9f61b15 (Create server sessions at activation instead of queueing requests)
 	const resolveServerSpec = async (uriObj: Uri): Promise<ServerSpec> => {
 		const wsFolderUriString = workspace.getWorkspaceFolder(uriObj)?.uri.toString();
 		const serverSpec = objectScriptApi.serverForUri(uriObj);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -39,11 +39,14 @@ export let client: LanguageClient;
 /**
  * Cache for cookies from REST requests to InterSystems servers.
  */
-const cookiesCache: Map<string, string[]> = new Map();
+const cookiesCache: Map<string, {
+	promise: Promise<string[]>,
+	resolve?: (value: string[]) => void,
+}> = new Map();
 
-export function updateCookies(newCookies: string[], server: ServerSpec): string[] {
+export async function updateCookies(newCookies: string[], server: ServerSpec): Promise<string[]> {
 	const key = `${server.username}@${server.host}:${server.port}${server.pathPrefix}`;
-	const cookies = cookiesCache.get(key) ?? [];
+	const cookies = await (cookiesCache.get(key)?.promise ?? emptyCookies());
 	newCookies.forEach((cookie) => {
 		const [cookieName] = cookie.split("=");
 		const index = cookies.findIndex((el) => el.startsWith(cookieName));
@@ -53,12 +56,33 @@ export function updateCookies(newCookies: string[], server: ServerSpec): string[
 			cookies.push(cookie);
 		}
 	});
-	cookiesCache.set(key, cookies);
+	const cache = cookiesCache.get(key);
+	if (cache && cache.resolve) {
+		cache.resolve(cookies)
+		delete cache.resolve
+	} else {
+		cookiesCache.set(key, { promise: new Promise((resolve) => resolve(cookies)) });
+	}
 	return cookies;
 }
 
-export function getCookies(server: ServerSpec): string[] {
-	return cookiesCache.get(`${server.username}@${server.host}:${server.port}${server.pathPrefix}`) ?? [];
+function emptyCookies(): Promise<string[]> {
+	return new Promise((resolve) => resolve([]))
+}
+
+// Each getCookies call MUST be accompanied by some calls to updateCookies
+export async function getCookies(server: ServerSpec): Promise<string[]> {
+	const key = `${server.username}@${server.host}:${server.port}${server.pathPrefix}`;
+	if (cookiesCache.has(key)) {
+		// A typical caller waits for the cookie promise to resolve.
+		return cookiesCache.get(key).promise
+	} else {
+		// The first caller for this key gets the empty cookies immediately.
+		let resolve: (value: string[]) => void;
+		const promise: Promise<string[]> = new Promise((r) => resolve = r);
+		cookiesCache.set(key, { promise, resolve })
+		return emptyCookies();
+	}
 }
 
 let objectScriptApi: any;
@@ -282,12 +306,12 @@ export async function activate(context: ExtensionContext) {
 								: uri.path.split("/").slice(1).join(".");
 						const docParams =
 							params.server.apiVersion >= 4 &&
-							workspace
-								.getConfiguration(
-									"objectscript",
-									workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
-								)
-								.get<boolean>("multilineMethodArgs")
+								workspace
+									.getConfiguration(
+										"objectscript",
+										workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
+									)
+									.get<boolean>("multilineMethodArgs")
 								? { format: "udl-multiline" }
 								: undefined;
 						const resp = await makeRESTRequest(
@@ -419,7 +443,7 @@ export async function deactivate(): Promise<void> {
 	for (const f of workspace.workspaceFolders ?? []) {
 		const serverSpec = wsFolderServerSpecs.get(f.uri.toString());
 		if (!serverSpec?.active) continue;
-		const sessionCookie = getCookies(serverSpec).find((c) => c.startsWith("CSPSESSIONID-"));
+		const sessionCookie = (await getCookies(serverSpec)).find((c) => c.startsWith("CSPSESSIONID-"));
 		if (!sessionCookie || loggedOut.has(sessionCookie)) continue;
 		loggedOut.add(sessionCookie);
 		promises.push(

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -285,12 +285,12 @@ export async function activate(context: ExtensionContext) {
 								: uri.path.split("/").slice(1).join(".");
 						const docParams =
 							params.server.apiVersion >= 4 &&
-								workspace
-									.getConfiguration(
-										"objectscript",
-										workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
-									)
-									.get<boolean>("multilineMethodArgs")
+							workspace
+								.getConfiguration(
+									"objectscript",
+									workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
+								)
+								.get<boolean>("multilineMethodArgs")
 								? { format: "udl-multiline" }
 								: undefined;
 						const resp = await makeRESTRequest(
@@ -332,6 +332,7 @@ export async function activate(context: ExtensionContext) {
 	// Start the client. This will also launch the server
 	await client.start();
 
+	// Ensure that every server has at most one session.
 	for (const f of workspace.workspaceFolders ?? []) {
 		try {
 			const serverSpec = await resolveServerSpec(f.uri);

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -330,17 +330,12 @@ export async function activate(context: ExtensionContext) {
 	);
 
 	// Start the client. This will also launch the server
-	client.start();
+	await client.start();
 
-	// Establish one session with each server used by the workspace before
-	// activation completes. Since IntelliSense requests aren't sent until after
-	// activation finishes, they will all reuse these sessions rather than each
-	// creating a new one when many editor tabs are open at startup (#406).
 	for (const f of workspace.workspaceFolders ?? []) {
 		try {
 			const serverSpec = await resolveServerSpec(f.uri);
 			if (!serverSpec.active || !serverSpec.apiVersion) continue;
-			// A GET request authenticates and caches the session cookie
 			await makeRESTRequest("GET", 1, "", serverSpec);
 		} catch {
 			// Ignore any failure; the session will be created on demand instead

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -164,8 +164,13 @@ export async function activate(context: ExtensionContext) {
 		});
 	}
 
+<<<<<<< HEAD
 	// Resolve the ServerSpec for a document or workspace folder URI, prompting
 	// for a missing password via the Server Manager's authentication provider.
+=======
+	// Resolve the ServerSpec for a document or workspace folder URI, prompting for
+	// a missing password via the Server Manager's authentication provider.
+>>>>>>> 9f61b15 (Create server sessions at activation instead of queueing requests)
 	const resolveServerSpec = async (uriObj: Uri): Promise<ServerSpec> => {
 		const wsFolderUriString = workspace.getWorkspaceFolder(uriObj)?.uri.toString();
 		const serverSpec = objectScriptApi.serverForUri(uriObj);
@@ -285,12 +290,12 @@ export async function activate(context: ExtensionContext) {
 								: uri.path.split("/").slice(1).join(".");
 						const docParams =
 							params.server.apiVersion >= 4 &&
-							workspace
-								.getConfiguration(
-									"objectscript",
-									workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
-								)
-								.get<boolean>("multilineMethodArgs")
+								workspace
+									.getConfiguration(
+										"objectscript",
+										workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
+									)
+									.get<boolean>("multilineMethodArgs")
 								? { format: "udl-multiline" }
 								: undefined;
 						const resp = await makeRESTRequest(

--- a/client/src/makeRESTRequest.ts
+++ b/client/src/makeRESTRequest.ts
@@ -52,8 +52,8 @@ export async function makeRESTRequest(
 		// The server doesn't support the Atelier API version required to make this request
 		client.warn(
 			"Cannot make required REST request to server " +
-			`${server.serverName !== "" ? `'${server.serverName}'` : `${server.host}:${server.port}${server.pathPrefix}`} ` +
-			`because it does not support the '${path}' endpoint, which requires Atelier API version ${api}.`,
+				`${server.serverName !== "" ? `'${server.serverName}'` : `${server.host}:${server.port}${server.pathPrefix}`} ` +
+				`because it does not support the '${path}' endpoint, which requires Atelier API version ${api}.`,
 		);
 		return undefined;
 	}
@@ -74,7 +74,7 @@ export async function makeRESTRequest(
 	const httpsAgent = new https.Agent({ rejectUnauthorized: workspace.getConfiguration("http").get("proxyStrictSSL") });
 
 	// Get the cookies
-	let cookies: string[] = await getCookies(server);
+	let cookies: string[] = getCookies(server);
 
 	// Make the request
 	try {
@@ -96,7 +96,7 @@ export async function makeRESTRequest(
 					return status < 500;
 				},
 			});
-			cookies = await updateCookies(respdata.headers["set-cookie"] || [], server);
+			cookies = updateCookies(respdata.headers["set-cookie"] || [], server);
 			if (respdata.status === 202) {
 				// The schema is being recalculated so we need to make another call to get it
 				respdata = await axios.request({
@@ -108,7 +108,7 @@ export async function makeRESTRequest(
 						Cookie: cookies.join(" "),
 					},
 				});
-				await updateCookies(respdata.headers["set-cookie"] || [], server);
+				updateCookies(respdata.headers["set-cookie"] || [], server);
 				return respdata;
 			} else if (respdata.status === 304) {
 				// The schema hasn't changed
@@ -129,7 +129,7 @@ export async function makeRESTRequest(
 					withCredentials: true,
 					httpsAgent,
 				});
-				cookies = await updateCookies(respdata.headers["set-cookie"] || [], server);
+				cookies = updateCookies(respdata.headers["set-cookie"] || [], server);
 				if (respdata.status === 202) {
 					// The schema is being recalculated so we need to make another call to get it
 					respdata = await axios.request({
@@ -141,7 +141,7 @@ export async function makeRESTRequest(
 							Cookie: cookies.join(" "),
 						},
 					});
-					await updateCookies(respdata.headers["set-cookie"] || [], server);
+					updateCookies(respdata.headers["set-cookie"] || [], server);
 					return respdata;
 				} else if (respdata.status === 304) {
 					// The schema hasn't changed
@@ -189,7 +189,7 @@ export async function makeRESTRequest(
 						httpsAgent,
 					});
 				}
-				await updateCookies(respdata.headers["set-cookie"] || [], server);
+				updateCookies(respdata.headers["set-cookie"] || [], server);
 			} else {
 				respdata = await axios.request({
 					method: method,
@@ -220,14 +220,14 @@ export async function makeRESTRequest(
 						params: params,
 					});
 				}
-				await updateCookies(respdata.headers["set-cookie"] || [], server);
+				updateCookies(respdata.headers["set-cookie"] || [], server);
 			}
 			return respdata;
 		}
 	} catch (error) {
-		await updateCookies(cookies, server)
 		client.warn(
-			`Error making REST request ${method} ${path}: ${typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error)
+			`Error making REST request ${method} ${path}: ${
+				typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error)
 			}`,
 		);
 		return undefined;

--- a/client/src/makeRESTRequest.ts
+++ b/client/src/makeRESTRequest.ts
@@ -52,8 +52,8 @@ export async function makeRESTRequest(
 		// The server doesn't support the Atelier API version required to make this request
 		client.warn(
 			"Cannot make required REST request to server " +
-				`${server.serverName !== "" ? `'${server.serverName}'` : `${server.host}:${server.port}${server.pathPrefix}`} ` +
-				`because it does not support the '${path}' endpoint, which requires Atelier API version ${api}.`,
+			`${server.serverName !== "" ? `'${server.serverName}'` : `${server.host}:${server.port}${server.pathPrefix}`} ` +
+			`because it does not support the '${path}' endpoint, which requires Atelier API version ${api}.`,
 		);
 		return undefined;
 	}
@@ -74,7 +74,7 @@ export async function makeRESTRequest(
 	const httpsAgent = new https.Agent({ rejectUnauthorized: workspace.getConfiguration("http").get("proxyStrictSSL") });
 
 	// Get the cookies
-	let cookies: string[] = getCookies(server);
+	let cookies: string[] = await getCookies(server);
 
 	// Make the request
 	try {
@@ -96,7 +96,7 @@ export async function makeRESTRequest(
 					return status < 500;
 				},
 			});
-			cookies = updateCookies(respdata.headers["set-cookie"] || [], server);
+			cookies = await updateCookies(respdata.headers["set-cookie"] || [], server);
 			if (respdata.status === 202) {
 				// The schema is being recalculated so we need to make another call to get it
 				respdata = await axios.request({
@@ -108,7 +108,7 @@ export async function makeRESTRequest(
 						Cookie: cookies.join(" "),
 					},
 				});
-				updateCookies(respdata.headers["set-cookie"] || [], server);
+				await updateCookies(respdata.headers["set-cookie"] || [], server);
 				return respdata;
 			} else if (respdata.status === 304) {
 				// The schema hasn't changed
@@ -129,7 +129,7 @@ export async function makeRESTRequest(
 					withCredentials: true,
 					httpsAgent,
 				});
-				cookies = updateCookies(respdata.headers["set-cookie"] || [], server);
+				cookies = await updateCookies(respdata.headers["set-cookie"] || [], server);
 				if (respdata.status === 202) {
 					// The schema is being recalculated so we need to make another call to get it
 					respdata = await axios.request({
@@ -141,7 +141,7 @@ export async function makeRESTRequest(
 							Cookie: cookies.join(" "),
 						},
 					});
-					updateCookies(respdata.headers["set-cookie"] || [], server);
+					await updateCookies(respdata.headers["set-cookie"] || [], server);
 					return respdata;
 				} else if (respdata.status === 304) {
 					// The schema hasn't changed
@@ -189,7 +189,7 @@ export async function makeRESTRequest(
 						httpsAgent,
 					});
 				}
-				updateCookies(respdata.headers["set-cookie"] || [], server);
+				await updateCookies(respdata.headers["set-cookie"] || [], server);
 			} else {
 				respdata = await axios.request({
 					method: method,
@@ -220,14 +220,14 @@ export async function makeRESTRequest(
 						params: params,
 					});
 				}
-				updateCookies(respdata.headers["set-cookie"] || [], server);
+				await updateCookies(respdata.headers["set-cookie"] || [], server);
 			}
 			return respdata;
 		}
 	} catch (error) {
+		await updateCookies(cookies, server)
 		client.warn(
-			`Error making REST request ${method} ${path}: ${
-				typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error)
+			`Error making REST request ${method} ${path}: ${typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error)
 			}`,
 		);
 		return undefined;


### PR DESCRIPTION
## Problem

When VS Code opens with many tabs, each tab concurrently calls `makeRESTRequest()`, creating multiple sessions to the same server.

## Solution

Serialize REST requests per server using promise-based queueing:

- First request authenticates and stores session cookie
- Concurrent requests wait and reuse the session cookie
- Subsequent requests use cached cookies immediately

## Changes

- Changed `cookiesCache` to store promises instead of raw cookie arrays
- Made `getCookies()`/`updateCookies()` async with queue logic
- Added `updateCookies()` in catch block to ensure promises always resolve