### PR TITLE
Fix incompatibilities with pre-OAuth2 version of Server Manager

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@intersystems-community/intersystems-servermanager": "^3.14.0",
+        "@intersystems-community/intersystems-servermanager": "^3.14.0-beta",
         "@types/semver": "^7.7.0",
         "@types/vscode": "1.93.0"
       },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@intersystems-community/intersystems-servermanager": "^3.14.0-beta",
+        "@intersystems-community/intersystems-servermanager": "^3.14.1",
         "@types/semver": "^7.7.0",
         "@types/vscode": "1.93.0"
       },
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@intersystems-community/intersystems-servermanager": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.14.0.tgz",
-      "integrity": "sha512-VKitwu5OTCHUT5ABs13/pldNLn4rdjfVBSM0gKnEfR+pPHBTaTgtCARoqiPqGIkLghHl2LToFunCRlTdQhDV+A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.14.1.tgz",
+      "integrity": "sha512-sGOq2agsIdN0dO6AwqciSbt8bV/y2gLBuRpiyq7hUR/7liE7s5a2EbYryN6A+h6J2lHLo/akiFz1ipmckIXvvg==",
       "dev": true,
       "license": "MIT"
     },
@@ -414,9 +414,9 @@
   },
   "dependencies": {
     "@intersystems-community/intersystems-servermanager": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.14.0.tgz",
-      "integrity": "sha512-VKitwu5OTCHUT5ABs13/pldNLn4rdjfVBSM0gKnEfR+pPHBTaTgtCARoqiPqGIkLghHl2LToFunCRlTdQhDV+A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@intersystems-community/intersystems-servermanager/-/intersystems-servermanager-3.14.1.tgz",
+      "integrity": "sha512-sGOq2agsIdN0dO6AwqciSbt8bV/y2gLBuRpiyq7hUR/7liE7s5a2EbYryN6A+h6J2lHLo/akiFz1ipmckIXvvg==",
       "dev": true
     },
     "@types/semver": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
-    "@intersystems-community/intersystems-servermanager": "^3.14.0",
+    "@intersystems-community/intersystems-servermanager": "^3.14.0-beta",
     "@types/semver": "^7.7.0",
     "@types/vscode": "1.93.0"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
-    "@intersystems-community/intersystems-servermanager": "^3.14.0-beta",
+    "@intersystems-community/intersystems-servermanager": "^3.14.1",
     "@types/semver": "^7.7.0",
     "@types/vscode": "1.93.0"
   }

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -22,7 +22,7 @@ import { client } from "./extension";
  */
 export async function overrideClassMembers() {
 	// Get the open document and check that it's an ObjectScript class
-	const openDoc = window.activeTextEditor.document;
+	const openDoc = window.activeTextEditor!.document;
 	if (openDoc.languageId != "objectscript-class") {
 		// Can only override members in a class
 		return;
@@ -48,7 +48,7 @@ export async function overrideClassMembers() {
 	}
 
 	// Check that we can insert new class members at the cursor position
-	const selection = window.activeTextEditor.selection;
+	const selection = window.activeTextEditor!.selection;
 	let cursorvalid = false;
 	let docposvalid = false;
 	if (openDoc.lineAt(selection.active.line).isEmptyOrWhitespace && selection.isEmpty) {
@@ -175,10 +175,10 @@ export async function selectImportPackage(uri: string, classname: string) {
 		selectedPackage = allimportpackages[0];
 	} else {
 		// Ask the user to select an import package
-		selectedPackage = await window.showQuickPick(allimportpackages, {
+		selectedPackage = (await window.showQuickPick(allimportpackages, {
 			title: "Pick the package to import",
 			canPickMany: false,
-		});
+		}))!;
 		if (!selectedPackage) {
 			// No package was selected
 			return;
@@ -206,7 +206,7 @@ export async function extractMethod(
 	newmethodtype: string,
 ) {
 	// Get the list of class member names
-	const symbols = await commands.executeCommand("vscode.executeDocumentSymbolProvider", Uri.parse(uri));
+	const symbols: any[] = await commands.executeCommand("vscode.executeDocumentSymbolProvider", Uri.parse(uri));
 	const clsmembers: string[] = [];
 	for (let clsmember = 0; clsmember < symbols[0].children.length; clsmember++) {
 		clsmembers.push(symbols[0].children[clsmember].name);
@@ -261,20 +261,20 @@ export async function extractMethod(
 	await workspace.applyEdit(await client.protocol2CodeConverter.asWorkspaceEdit(lspWorkspaceEdit));
 
 	// Highlight and scroll to new extracted method
-	const activeEditor = window.activeTextEditor;
+	const activeEditor = window.activeTextEditor!;
 	if (activeEditor.document.uri.toString() === uri) {
 		// Selection of the extracted method
-		const anchor = lspWorkspaceEdit.changes[uri][0].range.start;
+		const anchor = lspWorkspaceEdit.changes![uri][0].range.start;
 		let methodstring: string = "";
-		for (let edit = 0; edit < lspWorkspaceEdit.changes[uri].length - 2; edit++) {
-			methodstring += lspWorkspaceEdit.changes[uri][edit].newText;
+		for (let edit = 0; edit < lspWorkspaceEdit.changes![uri].length - 2; edit++) {
+			methodstring += lspWorkspaceEdit.changes![uri][edit].newText;
 		}
 		const methodsize = methodstring.split("\n").length - 1;
 		const range: Range = new Range(new Position(anchor.line + 1, 0), new Position(anchor.line + methodsize, 1));
 
 		// Selection of the method call
-		const anchor2 = lspWorkspaceEdit.changes[uri][lspWorkspaceEdit.changes[uri].length - 1].range.start;
-		const linesize = lspWorkspaceEdit.changes[uri][lspWorkspaceEdit.changes[uri].length - 1].newText.length;
+		const anchor2 = lspWorkspaceEdit.changes![uri][lspWorkspaceEdit.changes![uri].length - 1].range.start;
+		const linesize = lspWorkspaceEdit.changes![uri][lspWorkspaceEdit.changes![uri].length - 1].newText.length;
 		const range2: Range = new Range(
 			new Position(anchor2.line + methodsize + 1, anchor2.character),
 			new Position(anchor2.line + methodsize + 1, anchor2.character + linesize + 1),

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -35,6 +35,7 @@ import { makeRESTRequest } from "./makeRESTRequest";
 import { ISCEmbeddedContentProvider, requestForwardingMiddleware } from "./requestForwarding";
 import type { ServerSpec, ProtocolMethods } from "../../common/out/types";
 import type { Disposable } from "vscode-languageclient";
+import { Authorization, ResolvedAuthorization } from '@intersystems-community/intersystems-servermanager';
 
 export let client: {
 	onRequest<K extends keyof ProtocolMethods>(
@@ -168,7 +169,8 @@ export async function activate(context: ExtensionContext) {
 	// for a missing password via the Server Manager's authentication provider.
 	async function resolveServerSpec(uri: Uri) {
 		const wsFolderUriString = workspace.getWorkspaceFolder(uri)?.uri.toString();
-		const { auth, ...serverSpec } = objectScriptApi.serverForUri(uri);
+		const serverSpec = objectScriptApi.serverForUri(uri)!;
+		const auth = serverSpec.auth ?? new BasicAuthorization(serverSpec.username, serverSpec.password);
 		if (
 			// Server was resolved
 			serverSpec.host !== "" &&
@@ -454,4 +456,60 @@ export async function deactivate(): Promise<void> {
 		);
 	}
 	await Promise.allSettled(promises);
+}
+
+
+// A copy of the BasicAuthorization class from ServerManager
+// We use it to patch older version of getServerSpec.
+export default class BasicAuthorization implements Authorization {
+	#username?: string;
+	#password?: string;
+	constructor(username?: string, password?: string) {
+		this.#username = username;
+		this.#password = password;
+	}
+
+	public get username(): string {
+		return this.#username || "";
+	}
+
+	public get password(): string | undefined {
+		return this.#password;
+	}
+
+	public get accessToken(): string | undefined {
+		return this.#password;
+	}
+
+	public get httpAuthorizationHeader(): string {
+		return `Basic ${Buffer.from(`${this.#username}:${this.#password}`).toString("base64")}`;
+	}
+
+	public resolved(): this is ResolvedAuthorization {
+		return this.username !== "" && this.#password !== undefined;
+	}
+
+	public resolve(param: { accessToken: string; username?: string }): this is ResolvedAuthorization {
+		this.#username = param.username ?? this.#username;
+		this.#password = param.accessToken ?? this.#password;
+		return this.resolved();
+	}
+
+	public clear(): asserts this is Authorization {
+		this.#password = undefined;
+	}
+
+	public get credentials(): { auth: { username: string; password: string }; headers?: Record<string, string> } {
+		return {
+			auth: {
+				username: this.username,
+				password: this.password!,
+			},
+			headers: {},
+		};
+	}
+
+	public clone(): BasicAuthorization {
+		return new BasicAuthorization(this.#username, this.#password);
+	}
 }

--- a/client/src/requestForwarding.ts
+++ b/client/src/requestForwarding.ts
@@ -140,7 +140,7 @@ export const requestForwardingMiddleware: Middleware = {
 };
 
 export class ISCEmbeddedContentProvider implements TextDocumentContentProvider {
-	constructor() {}
+	constructor() { }
 
 	provideTextDocumentContent(uri: Uri): ProviderResult<string> {
 		// Get the isclexer language number and position from the URI authority
@@ -148,7 +148,7 @@ export class ISCEmbeddedContentProvider implements TextDocumentContentProvider {
 		const positionText = uri.authority.split(":")[1];
 		const position = new Position(Number(positionText.split("-")[0]), Number(positionText.split("-")[1]));
 		// Use the language number to isolate the original URI
-		let originalUri: string;
+		let originalUri: string | undefined;
 		if (language == 11) {
 			// Language is JavaScript so the extension is .js
 			originalUri = uri.path.slice(1).slice(0, -3);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,7 +5,8 @@
 		"target": "es6",
 		"outDir": "out",
 		"rootDir": "src",
-		"sourceMap": true
+		"sourceMap": true,
+ 	   	"strictNullChecks": true,
 	},
 	"include": ["src"],
 	"exclude": ["node_modules", ".vscode-test"]

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "@intersystems/language-server-common",
       "version": "2.8.4-SNAPSHOT",
-      "dependencies": {
-        "vscode-languageserver-protocol": "^3.17.5"
-      },
       "devDependencies": {
         "@types/node": "^18.19.50",
         "typescript": "^5.6.2"
@@ -44,31 +41,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-jsonrpc": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
-      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
-      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "9.0.1",
-        "vscode-languageserver-types": "3.18.0"
-      }
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
-      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     }
   }

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -10,8 +10,9 @@
 		"declarationMap": true,
 		"strict": true,
 		"esModuleInterop": true,
-		"skipLibCheck": true
-	},
+		"skipLibCheck": true,
+ 	   	"strictNullChecks": true,
+ 	},
 	"include": ["src"],
 	"exclude": ["node_modules", "out"]
 }

--- a/server/src/providers/completion.ts
+++ b/server/src/providers/completion.ts
@@ -578,9 +578,8 @@ async function completionFullClassName(
 
 	// Get all classes
 	const querydata = {
-		query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${
-			!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-		}`,
+		query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+			}`,
 		parameters: ["*.cls", 1, 1, 1, 1, 0, settings.completion.showGenerated ? 1 : 0],
 	};
 	const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -590,7 +589,7 @@ async function completionFullClassName(
 			let compItem: CompletionItem;
 			if (imports.length > 0) {
 				// Resolve import
-				let sortText: string;
+				let sortText: string | undefined;
 				for (const imp of imports) {
 					if (displayname.indexOf(imp) === 0 && displayname.slice(imp.length + 1).indexOf(".") === -1) {
 						displayname = displayname.slice(imp.length + 1);
@@ -638,9 +637,8 @@ async function completionPackage(server: ServerSpec, settings: LanguageServerCon
 
 	// Get all the packages
 	const querydata = {
-		query: `SELECT DISTINCT $PIECE(dcd.Name,'.',1,$LENGTH(dcd.Name,'.')-1) AS Package FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${
-			!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-		}`,
+		query: `SELECT DISTINCT $PIECE(dcd.Name,'.',1,$LENGTH(dcd.Name,'.')-1) AS Package FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+			}`,
 		parameters: ["*.cls", 1, 1, 1, 1, 0, settings.completion.showGenerated ? 1 : 0],
 	};
 	const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -692,7 +690,7 @@ async function globalsOrRoutines(
 	server: ServerSpec,
 	lineText: string,
 	prefix: string = "",
-): Promise<CompletionItem[]> {
+): Promise<CompletionItem[] | null> {
 	// Determine if this is a routine or global, and return null if we're in $BITLOGIC
 	let brk = false,
 		parenLevel = 0,
@@ -756,13 +754,13 @@ async function globalsOrRoutines(
 		server,
 		isRoutine
 			? {
-					query: `SELECT DISTINCT $PIECE(Name,'.',1,$LENGTH(Name,'.')-1) AS Name FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,1,1,1,0,'NOT (Name %PATTERN ''.E1"."0.1"G"1N1".obj"'' AND $LENGTH(Name,''.'') > 3)')`,
-					parameters: [`${prefix.length ? `${prefix.slice(0, -1)}/` : ""}*.mac,*.int,*.obj`],
-				}
+				query: `SELECT DISTINCT $PIECE(Name,'.',1,$LENGTH(Name,'.')-1) AS Name FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,1,1,1,0,'NOT (Name %PATTERN ''.E1"."0.1"G"1N1".obj"'' AND $LENGTH(Name,''.'') > 3)')`,
+				parameters: [`${prefix.length ? `${prefix.slice(0, -1)}/` : ""}*.mac,*.int,*.obj`],
+			}
 			: {
-					query: "SELECT Name FROM %SYS.GlobalQuery_NameSpaceList(,?,?,,,1,0)",
-					parameters: [`${prefix}*`, (await showInternalForServer(server)) ? 1 : 0],
-				},
+				query: "SELECT Name FROM %SYS.GlobalQuery_NameSpaceList(,?,?,,,1,0)",
+				parameters: [`${prefix}*`, (await showInternalForServer(server)) ? 1 : 0],
+			},
 	);
 	if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 		return respdata.data.result.content.map((item: { Name: string }) => {
@@ -1120,9 +1118,8 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 		// Get all appropriate subclasses of %Query
 		const querydata = {
-			query: `SELECT dcd.Name, Deprecated FROM %Dictionary.ClassDefinition_SubclassOf(?) AS sco, %Dictionary.ClassDefinition AS dcd WHERE sco.Name = dcd.Name AND sco.Name NOT %INLIST $LISTFROMSTRING(?)${
-				!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-			}`,
+			query: `SELECT dcd.Name, Deprecated FROM %Dictionary.ClassDefinition_SubclassOf(?) AS sco, %Dictionary.ClassDefinition AS dcd WHERE sco.Name = dcd.Name AND sco.Name NOT %INLIST $LISTFROMSTRING(?)${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+				}`,
 			parameters: ["%Library.Query", "%Library.ExtentSQLQuery,%Library.RowSQLQuery"],
 		};
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -1131,7 +1128,7 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 				let displayname: string = clsobj.Name;
 				if (imports.length > 0) {
 					// Resolve import
-					let sortText: string;
+					let sortText: string | undefined;
 					for (const imp of imports) {
 						if (displayname.indexOf(imp) === 0 && displayname.slice(imp.length + 1).indexOf(".") === -1) {
 							displayname = displayname.slice(imp.length + 1);
@@ -1260,9 +1257,8 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 			// Get all classes that match the filter
 			const querydata = {
-				query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${
-					!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-				}`,
+				query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+					}`,
 				parameters: ["*.cls", 1, 1, 1, 1, 0, settings.completion.showGenerated ? 1 : 0, `Name %STARTSWITH '${filter}'`],
 			};
 			const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -1281,7 +1277,7 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 		} else if (globalOrRoutineMatch && triggerlang == ld.cos_langindex) {
 			// This might be a routine or global
 
-			result = await globalsOrRoutines(
+			result = (await globalsOrRoutines(
 				doc,
 				parsed,
 				params.position.line,
@@ -1290,7 +1286,7 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 				server,
 				prevline.slice(0, -globalOrRoutineMatch[1].length),
 				globalOrRoutineMatch[1],
-			);
+			))!;
 		} else {
 			// This is a class member
 
@@ -1306,11 +1302,10 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 				// Query the server to get the names and descriptions of all parameters
 				const data: QueryData = {
-					query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${
-						membercontext.context == "instance"
-							? " AND (parent->ClassType IS NULL OR parent->ClassType != 'datatype')"
-							: ""
-					}${internalStr}${deprecatedStr}`,
+					query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${membercontext.context == "instance"
+						? " AND (parent->ClassType IS NULL OR parent->ClassType != 'datatype')"
+						: ""
+						}${internalStr}${deprecatedStr}`,
 					parameters: [membercontext.baseclass],
 				};
 				const respdata = await makeRESTRequest("POST", 1, "/action/query", server, data);
@@ -1620,11 +1615,10 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 		// Query the server to get the names and descriptions of all class-specific parameters
 		const data: QueryData = {
-			query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${
-				isProperty
-					? " OR Parent %INLIST (SELECT $LISTFROMSTRING(PropertyClass) FROM %Dictionary.CompiledClass WHERE Name = ?)"
-					: ""
-			}${!(await showInternalForServer(server)) ? " AND Internal = 0" : ""}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
+			query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${isProperty
+				? " OR Parent %INLIST (SELECT $LISTFROMSTRING(PropertyClass) FROM %Dictionary.CompiledClass WHERE Name = ?)"
+				: ""
+				}${!(await showInternalForServer(server)) ? " AND Internal = 0" : ""}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
 			parameters: isProperty ? [normalizedcls, currentClass(doc, parsed)] : [normalizedcls],
 		};
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, data);
@@ -1939,9 +1933,8 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 						}
 					}
 					const querydata = {
-						query: `SELECT Name, Description, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ?${
-							!(await showInternalForServer(server)) ? " AND Internal = 0" : ""
-						}`,
+						query: `SELECT Name, Description, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ?${!(await showInternalForServer(server)) ? " AND Internal = 0" : ""
+							}`,
 						parameters: [thisclass],
 					};
 					const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -2384,9 +2377,8 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 		// Query the server to get the names and descriptions of all non-calculated properties
 		const data: QueryData = {
-			query: `SELECT Name, Description, Origin, RuntimeType, Deprecated FROM %Dictionary.CompiledProperty WHERE Parent = ? AND Calculated = 0${
-				!showInternal ? " AND Internal = 0" : ""
-			}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
+			query: `SELECT Name, Description, Origin, RuntimeType, Deprecated FROM %Dictionary.CompiledProperty WHERE Parent = ? AND Calculated = 0${!showInternal ? " AND Internal = 0" : ""
+				}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
 			parameters: [thisclass],
 		};
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, data);
@@ -2422,7 +2414,7 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 	} else if (prevline.endsWith("^") && triggerlang == ld.cos_langindex) {
 		// This might be a routine or global
 
-		result = await globalsOrRoutines(doc, parsed, params.position.line, thistoken, settings, server, prevline);
+		result = (await globalsOrRoutines(doc, parsed, params.position.line, thistoken, settings, server, prevline))!;
 	}
 	return result;
 }

--- a/server/src/providers/definition.ts
+++ b/server/src/providers/definition.ts
@@ -214,7 +214,7 @@ function findMemberInCurrentClass(
 	}
 }
 
-export async function onDefinition(params: TextDocumentPositionParams): Promise<LocationLink[]> {
+export async function onDefinition(params: TextDocumentPositionParams): Promise<LocationLink[] | null | undefined> {
 	const doc = documents.get(params.textDocument.uri);
 	if (doc === undefined) {
 		return null;

--- a/server/src/providers/diagnostic.ts
+++ b/server/src/providers/diagnostic.ts
@@ -165,7 +165,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 							parsed[i][j].l == ld.cls_langindex &&
 							parsed[i][j].s == ld.cls_keyword_attrindex &&
 							doc.getText(Range.create(i, parsed[i][j].p, i, parsed[i][j].p + parsed[i][j].c)).toLowerCase() ==
-								"extends"
+							"extends"
 						) {
 							// The 'Extends' keyword is present
 							hassupers = true;
@@ -278,7 +278,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 
 	// Don't report diagnostics in a #if 0 block, and
 	// mark all of the code in the block as "unused"
-	let ifZeroStartPos: Position;
+	let ifZeroStartPos: Position | undefined;
 	const ifZeroStart = /^\s*#if\s+(?:0|"0")(?:$|\s)/i;
 	const ifZeroEnd = /^\s*#elseif\s+|(?:#else|#endif)(?:$|\s)/i;
 
@@ -383,7 +383,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 					parsed[i][j - 1].l == ld.cls_langindex &&
 					parsed[i][j - 1].s == ld.cls_keyword_attrindex &&
 					doc.getText(Range.create(i, parsed[i][j - 1].p, i, parsed[i][j - 1].p + parsed[i][j - 1].c)).toLowerCase() ===
-						"class"
+					"class"
 				) {
 					// This is the class name in the class definition line
 
@@ -400,7 +400,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 						});
 					} else if (isPersistent) {
 						// Check if a SqlTableName is present
-						let sqlTableName: Range,
+						let sqlTableName: Range | undefined,
 							hasSqlTableName = false;
 						for (let k = j + 1; k < parsed[i].length; k++) {
 							if (hasSqlTableName) {
@@ -422,7 +422,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 								parsed[i][k].l == ld.cls_langindex &&
 								parsed[i][k].s == ld.cls_keyword_attrindex &&
 								doc.getText(Range.create(i, parsed[i][k].p, i, parsed[i][k].p + parsed[i][k].c)).toLowerCase() ==
-									"sqltablename"
+								"sqltablename"
 							) {
 								hasSqlTableName = true;
 							}
@@ -437,9 +437,9 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 									source: "InterSystems Language Server",
 								});
 							}
-						} else if (sqlReservedWords.includes(word.split(".").pop().toUpperCase())) {
+						} else if (sqlReservedWords.includes(word.split(".").pop()!.toUpperCase())) {
 							// The short class name is a reserved word, and it's not corrected by a SqlTableName
-							wordrange.start.character = wordrange.end.character - word.split(".").pop().length;
+							wordrange.start.character = wordrange.end.character - word.split(".").pop()!.length;
 							diagnostics.push({
 								severity: DiagnosticSeverity.Warning,
 								range: wordrange,
@@ -453,7 +453,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 					parsed[i][j].l == ld.cls_langindex &&
 					parsed[i][j].s == ld.cls_keyword_attrindex &&
 					doc.getText(Range.create(i, parsed[i][j].p, i, parsed[i][j].p + parsed[i][j].c)).toLowerCase() ===
-						"parameter" &&
+					"parameter" &&
 					settings.diagnostics.parameters
 				) {
 					// This line is a UDL Parameter definition
@@ -531,11 +531,11 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 							// The type is valid
 
 							// See if this Parameter has a value
-							let valuetkn: number;
+							let valuetkn: number | undefined;
 							const delimtext = doc.getText(Range.create(i, parsed[i][4].p, i, parsed[i][4].p + parsed[i][4].c));
 							if (delimtext === "[") {
 								// Loop through the line to find the closing brace
-								let closingtkn: number;
+								let closingtkn: number | undefined;
 								for (let ptkn = 5; ptkn < parsed[i].length; ptkn++) {
 									if (
 										parsed[i][ptkn].l == ld.cls_langindex &&
@@ -815,8 +815,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 							// Add this class to the map
 							addRangeToMapVal(
 								otherNsDocs,
-								`${currentNs}:::${
-									!word.includes(".") && word.startsWith("%") ? `%Library.${word.slice(1)}` : word
+								`${currentNs}:::${!word.includes(".") && word.startsWith("%") ? `%Library.${word.slice(1)}` : word
 								}.cls`,
 								wordrange,
 							);
@@ -1186,7 +1185,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 					const propName = quoteUDLIdentifier(doc.getText(propRange), 0);
 
 					// Check if a SqlFieldName is present
-					let sqlFieldName: Range,
+					let sqlFieldName: Range | undefined,
 						hasSqlFieldName = false,
 						inKeywords = false,
 						brk = false;
@@ -1224,7 +1223,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 								parsed[ln][k].l == ld.cls_langindex &&
 								parsed[ln][k].s == ld.cls_keyword_attrindex &&
 								doc.getText(Range.create(ln, parsed[ln][k].p, ln, parsed[ln][k].p + parsed[ln][k].c)).toLowerCase() ==
-									"sqlfieldname"
+								"sqlfieldname"
 							) {
 								hasSqlFieldName = true;
 							} else if (

--- a/server/src/providers/documentSymbol.ts
+++ b/server/src/providers/documentSymbol.ts
@@ -117,7 +117,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 						0,
 						lastnonempty,
 						parsed[lastnonempty][parsed[lastnonempty].length - 1].p +
-							parsed[lastnonempty][parsed[lastnonempty].length - 1].c,
+						parsed[lastnonempty][parsed[lastnonempty].length - 1].c,
 					);
 
 					// Determine if this class is Deprecated
@@ -181,7 +181,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 							0,
 							lastNonEmpty,
 							parsed[lastNonEmpty][parsed[lastNonEmpty].length - 1].p +
-								parsed[lastNonEmpty][parsed[lastNonEmpty].length - 1].c,
+							parsed[lastNonEmpty][parsed[lastNonEmpty].length - 1].c,
 						),
 						selectionRange: Range.create(line, parsed[line][1].p, line, parsed[line][1].p + parsed[line][1].c),
 						tags: deprecated ? [SymbolTag.Deprecated] : undefined,
@@ -322,7 +322,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 					labelrange.start.line >= result[result.length - 1].range.start.line &&
 					labelrange.start.line <= result[result.length - 1].range.end.line;
 
-				let firstbrace: [number, number] | undefined = undefined;
+				let firstbrace: [number, number] | undefined;
 				if (!inProcedureBlock) {
 					// Check if this label is a procedure block
 					firstbrace = labelIsProcedureBlock(doc, parsed, line);
@@ -416,7 +416,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 					parsed[line][tkn + 1].l == ld.html_langindex &&
 					parsed[line][tkn + 1].s == ld.html_tag_attrindex &&
 					doc.getText(Range.create(line, parsed[line][tkn].p, line, parsed[line][tkn].p + parsed[line][tkn].c)) ===
-						"<" &&
+					"<" &&
 					doc
 						.getText(
 							Range.create(line, parsed[line][tkn + 1].p, line, parsed[line][tkn + 1].p + parsed[line][tkn + 1].c),

--- a/server/src/providers/foldingRange.ts
+++ b/server/src/providers/foldingRange.ts
@@ -736,7 +736,7 @@ export async function onFoldingRanges(params: FoldingRangeParams) {
 					parsed[line][tkn + 1].l == ld.html_langindex &&
 					parsed[line][tkn + 1].s == ld.html_tag_attrindex &&
 					doc.getText(Range.create(line, parsed[line][tkn].p, line, parsed[line][tkn].p + parsed[line][tkn].c)) ===
-						"<" &&
+					"<" &&
 					doc
 						.getText(
 							Range.create(line, parsed[line][tkn + 1].p, line, parsed[line][tkn + 1].p + parsed[line][tkn + 1].c),
@@ -790,7 +790,7 @@ export async function onFoldingRanges(params: FoldingRangeParams) {
 						});
 					} else if (inCComment && commentText.slice(-2) == "*/") {
 						// Close the most recent C-style comment range
-						const cCommentRange = openranges.pop();
+						const cCommentRange = openranges.pop()!;
 						cCommentRange.endLine = line - 1;
 						cCommentRange.kind = FoldingRangeKind.Comment;
 						if (cCommentRange.endLine > cCommentRange.startLine) result.push(cCommentRange);

--- a/server/src/providers/formatting.ts
+++ b/server/src/providers/formatting.ts
@@ -63,7 +63,7 @@ async function formatText(uri: DocumentUri, range?: Range): Promise<TextEdit[] |
 	}
 
 	let classes: StudioOpenDialogFile[] = [];
-	let inheritedpackages: string[] | undefined = undefined;
+	let inheritedpackages: string[] | undefined;
 	if (settings.formatting.expandClassNames) {
 		// Get all classes
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, {

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -54,7 +54,7 @@ function markupValue(header: string, body?: string): string {
 	return body?.trim().length ? [header, "***", body].join("\n") : header;
 }
 
-export async function onHover(params: TextDocumentPositionParams): Promise<Hover> {
+export async function onHover(params: TextDocumentPositionParams): Promise<Hover | null | undefined> {
 	const doc = documents.get(params.textDocument.uri);
 	if (doc === undefined) {
 		return null;
@@ -171,7 +171,7 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 							macrorange.end.character,
 							params.position.line,
 							parsed[params.position.line][parsed[params.position.line].length - 1].p +
-								parsed[params.position.line][parsed[params.position.line].length - 1].c,
+							parsed[params.position.line][parsed[params.position.line].length - 1].c,
 						),
 					);
 
@@ -472,15 +472,14 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 							value: ["$ZUTIL", "$ZU"].includes(sysftext)
 								? markupValue(`[Online documentation](${sysfdoc.link})`)
 								: markupValue(
-										sysfdoc.documentation.join(""),
-										sysfdoc.link
-											? `[Online documentation](${
-													sysfdoc.link[0] == "h"
-														? sysfdoc.link
-														: `https://docs.intersystems.com/irislatest/csp/docbook/Doc.View.cls?KEY=RCOS_${sysfdoc.link}`
-												})`
-											: "",
-									),
+									sysfdoc.documentation.join(""),
+									sysfdoc.link
+										? `[Online documentation](${sysfdoc.link[0] == "h"
+											? sysfdoc.link
+											: `https://docs.intersystems.com/irislatest/csp/docbook/Doc.View.cls?KEY=RCOS_${sysfdoc.link}`
+										})`
+										: "",
+								),
 						},
 						range: sysfrange,
 					};
@@ -1246,9 +1245,8 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 						if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 							// We got data back
 
-							const header = `(**${normalizedcls}**) <u>**${param}**</u>${
-								respdata.data.result.content[0].Type != "" ? ` As **${respdata.data.result.content[0].Type}**` : ""
-							}`;
+							const header = `(**${normalizedcls}**) <u>**${param}**</u>${respdata.data.result.content[0].Type != "" ? ` As **${respdata.data.result.content[0].Type}**` : ""
+								}`;
 							return {
 								contents: {
 									kind: MarkupKind.Markdown,

--- a/server/src/providers/refactoring.ts
+++ b/server/src/providers/refactoring.ts
@@ -419,7 +419,7 @@ export async function addOverridableMembers(params: AddOverridableMembersParams)
 	// Loop through the QuickPickItem array and map all origin classes to the members
 	const membersPerOrigin: Map<string, string[]> = new Map();
 	for (const member of params.members) {
-		const origin = member.detail.split(" ")[member.detail.split(" ").length - 1] + ".cls";
+		const origin = member.detail!.split(" ")[member.detail!.split(" ").length - 1] + ".cls";
 		if (membersPerOrigin.has(origin)) {
 			// Add this member to the array of members for this origin class
 			const membersarr = membersPerOrigin.get(origin);
@@ -757,7 +757,7 @@ export async function addMethod(params: AddMethodParams): Promise<WorkspaceEdit 
 	let foundprocedureblock: boolean = false;
 	let endprocedureblocksearch: boolean = false;
 	let nexttkn: number = 0;
-	let methodprocedureblock: boolean | undefined = undefined;
+	let methodprocedureblock: boolean | undefined;
 	const donorargs: [string, boolean, string][] = []; // List of arguments of the donor method
 	let donorarg: [string, boolean, string] = ["", false, ""]; // Argument properties: Name, ByRef/Output, Type/Parameters)
 	let previoustknln = params.lnmethod;

--- a/server/src/providers/rename.ts
+++ b/server/src/providers/rename.ts
@@ -63,7 +63,7 @@ export async function onPrepareRename(params: TextDocumentPositionParams) {
 				result = null;
 			} else {
 				// Check if this method is ProcedureBlock
-				let methodprocedureblock: boolean | undefined = undefined;
+				let methodprocedureblock: boolean | undefined;
 				if (
 					parsed[params.position.line][0].l === ld.cls_langindex &&
 					parsed[params.position.line][0].s === ld.cls_keyword_attrindex &&

--- a/server/src/providers/requestForwarding.ts
+++ b/server/src/providers/requestForwarding.ts
@@ -118,7 +118,7 @@ export async function isolateEmbeddedLanguage(params: IsolateEmbeddedLanguagePar
 
 		// Isolate HTML above this token
 		let ignoreHTML: boolean = false;
-		let firstEmb: "open" | "close" | undefined = undefined;
+		let firstEmb: "open" | "close" | undefined;
 		for (let line = params.position.line; line >= 0; line--) {
 			let starttkn = parsed[line].length - 1;
 			if (line == params.position.line) {

--- a/server/src/providers/signatureHelp.ts
+++ b/server/src/providers/signatureHelp.ts
@@ -34,12 +34,12 @@ let signatureHelpMacroCache: SignatureHelpMacroContext;
 /**
  * Cache of the documentation content sent for the last triggered SignatureHelp.
  */
-let signatureHelpDocumentationCache: SignatureHelpDocCache | undefined = undefined;
+let signatureHelpDocumentationCache: SignatureHelpDocCache | undefined;
 
 /**
  * The start position of the active SignatureHelp.
  */
-let signatureHelpStartPosition: Position | undefined = undefined;
+let signatureHelpStartPosition: Position | undefined;
 
 /** Placeholder for the Markdown emphasis characters before an argument. */
 const emphasizePrefix: string = "%%%%%";
@@ -198,10 +198,10 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 		triggerlang != ld.cos_langindex ||
 		// Don't compute signature help inside of a string literal
 		(doc.getText(Range.create(Position.create(params.position.line, 0), params.position)).split('"').length - 1) % 2 ==
-			1
+		1
 	) {
 		if (params.context.activeSignatureHelp) {
-			params.context.activeSignatureHelp.signatures[0].documentation = signatureHelpDocumentationCache.doc;
+			params.context.activeSignatureHelp.signatures[0].documentation = signatureHelpDocumentationCache!.doc;
 			return params.context.activeSignatureHelp;
 		} else {
 			return null;
@@ -365,16 +365,16 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 			const querydata =
 				member == "%New"
 					? {
-							// Get the information for both %New and %OnNew
-							query:
-								"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-							parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
-						}
+						// Get the information for both %New and %OnNew
+						query:
+							"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
+						parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
+					}
 					: {
-							query:
-								"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-							parameters: [membercontext.baseclass, unquotedname],
-						};
+						query:
+							"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
+						parameters: [membercontext.baseclass, unquotedname],
+					};
 			const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 			if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 				// We got data back
@@ -613,16 +613,16 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 				const querydata =
 					member == "%New"
 						? {
-								// Get the information for both %New and %OnNew
-								query:
-									"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-								parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
-							}
+							// Get the information for both %New and %OnNew
+							query:
+								"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
+							parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
+						}
 						: {
-								query:
-									"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-								parameters: [membercontext.baseclass, unquotedname],
-							};
+							query:
+								"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
+							parameters: [membercontext.baseclass, unquotedname],
+						};
 				const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 				if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 					// We got data back

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -168,7 +168,7 @@ connection.onNotification("intersystems/server/passwordChange", (serverName: str
 	for (const uri of invalid) {
 		serverSpecs.delete(uri);
 	}
-	let toRemove: ServerSpec | undefined = undefined;
+	let toRemove: ServerSpec | undefined;
 	for (const server of schemaCaches.keys()) {
 		if (server.serverName == serverName) {
 			toRemove = server;

--- a/server/src/utils/functions.ts
+++ b/server/src/utils/functions.ts
@@ -109,6 +109,7 @@ turndown.addRule("documaticArgs", {
 		if (node.children.length > 0) {
 			return `\n#### Arguments:\n${content}\n`;
 		}
+		return "";
 	},
 });
 turndown.addRule("documaticArg", {
@@ -118,6 +119,7 @@ turndown.addRule("documaticArg", {
 		if (attrVal !== null) {
 			return `\n- \`${attrVal}\` - ${content}`;
 		}
+		return "";
 	},
 });
 turndown.addRule("documaticReturn", {

--- a/server/src/utils/functions.ts
+++ b/server/src/utils/functions.ts
@@ -61,7 +61,7 @@ turndown.addRule("pre", {
 				/* empty */
 			}
 		} else {
-			switch (attrVal.split("!").shift().toUpperCase()) {
+			switch (attrVal.split("!").shift()!.toUpperCase()) {
 				case "OBJECTSCRIPT":
 				case "COS":
 				case "INT":
@@ -81,7 +81,7 @@ turndown.addRule("pre", {
 					break;
 				case "JAVASCRIPT":
 				case "JS":
-					lang = attrVal.split("!").pop().toUpperCase() == "JSON" ? "json" : "javascript";
+					lang = attrVal.split("!").pop()!.toUpperCase() == "JSON" ? "json" : "javascript";
 					break;
 				case "CSS":
 					lang = "css";
@@ -1343,7 +1343,7 @@ export async function findMethodParameterClass(
 	allfiles?: StudioOpenDialogFile[],
 	inheritedpackages?: string[],
 ): Promise<ClassMemberContext | undefined> {
-	let result: ClassMemberContext | undefined = undefined;
+	let result: ClassMemberContext | undefined;
 	for (let tkn = 0; tkn < parsed[line].length; tkn++) {
 		if (parsed[line][tkn].l == ld.cls_langindex && parsed[line][tkn].s == ld.cls_param_attrindex) {
 			// This is a parameter
@@ -1644,7 +1644,7 @@ async function determineParameterClass(
 	allfiles?: StudioOpenDialogFile[],
 	inheritedpackages?: string[],
 ): Promise<ClassMemberContext | undefined> {
-	let result: ClassMemberContext | undefined = undefined;
+	let result: ClassMemberContext | undefined;
 	if (doc.languageId === "objectscript-class") {
 		// Parameters can only have a type if they're in a UDL method
 
@@ -1736,7 +1736,7 @@ async function determineDeclaredLocalVarClass(
 	allfiles?: StudioOpenDialogFile[],
 	inheritedpackages?: string[],
 ): Promise<ClassMemberContext | undefined> {
-	let result: ClassMemberContext | undefined = undefined;
+	let result: ClassMemberContext | undefined;
 
 	if (varText === "%request") {
 		result = {
@@ -1893,11 +1893,11 @@ async function parseSetCommand(
 	let inPostconditional = false;
 	let pcParenCount = 0;
 	let foundVar = false;
-	let operatorTuple: [number, number] | undefined = undefined;
+	let operatorTuple: [number, number] | undefined;
 	let exprLeadingParenCount = 0;
 	let exprParenLevel = 0;
-	let firstExprTuple: [number, number] | undefined = undefined;
-	let lastMemTuple: [number, number] | undefined = undefined;
+	let firstExprTuple: [number, number] | undefined;
+	let lastMemTuple: [number, number] | undefined;
 	for (let ln = line; ln < parsed.length; ln++) {
 		if (!parsed[ln]?.length) continue;
 		for (let tkn = ln == line ? token + 1 : 0; tkn < parsed[ln].length; tkn++) {
@@ -2360,7 +2360,7 @@ async function determineUndeclaredLocalVarClass(
 	allfiles?: StudioOpenDialogFile[],
 	inheritedpackages?: string[],
 ): Promise<ClassMemberContext | undefined> {
-	let result: ClassMemberContext | undefined = undefined;
+	let result: ClassMemberContext | undefined;
 
 	// Scan to the top of the method to find where the variable was Set or passed by reference
 	let firstLabel = true;
@@ -3044,7 +3044,7 @@ export function labelIsProcedureBlock(
 ): [number, number] | undefined {
 	const lastLabelTkn = parsed[line].length > 1 && parsed[line][1].s == ld.cos_label_attrindex ? 1 : 0;
 	let currentLabelIsProcedureBlock: boolean = false;
-	let result: [number, number] | undefined = undefined;
+	let result: [number, number] | undefined;
 
 	if (
 		parsed[line].length > lastLabelTkn + 1 &&
@@ -3360,7 +3360,7 @@ export function urlMapAttribute(
 	parsed: compressedline[],
 	line: number,
 	token: number,
-): "Call" | "Forward" | "" {
+): "Call" | "Forward" | "" | undefined {
 	// Determine if we're in a UrlMap XData block
 	let inUrlMap = false;
 	for (let ln = line; ln >= 0; ln--) {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,7 +5,7 @@
 		"moduleResolution": "node16",
 		"sourceMap": true,
 		"strict": true,
-		"strictNullChecks": false,
+		"strictNullChecks": true,
 		"outDir": "out",
 		"rootDir": "src",
 		"noImplicitAny": false,


### PR DESCRIPTION
Enable strictNullChecks and fix a Server Manager compatibility bug

## Functional changes

- [client/src/extension.ts]: Patch ServerManagerAPI for compatibility with pre-OAuth2 versions of Server Manager: Construct a BasicAuthorization when Server Manager doesn't supply an auth object.
- [tsconfig.base.json]: Enable strictNullChecks, so mistakes like the ones above get caught by the compiler instead of at runtime.

## Non-functional changes

Everything else is mechanical fallout from enabling strictNullChecks, limited to:

- Adding a missing type annotation.
- Loosening a type annotation to include undefined/null where that reflects actual runtime behavior.
- Adding non-null assertions (!) to values of which the type is nullable.

No behavior changes outside the items listed above.