### PR TITLE
Fix hover intellisense for macros

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -35,16 +35,14 @@ import { makeRESTRequest } from "./makeRESTRequest";
 import { ISCEmbeddedContentProvider, requestForwardingMiddleware } from "./requestForwarding";
 import type { ServerSpec, ProtocolMethods } from "../../common/out/types";
 import type { Disposable } from "vscode-languageclient";
-import { Authorization, ResolvedAuthorization } from '@intersystems-community/intersystems-servermanager';
+import { Authorization, ResolvedAuthorization } from "@intersystems-community/intersystems-servermanager";
 
 export let client: {
 	onRequest<K extends keyof ProtocolMethods>(
 		method: K,
-		handler: (
-			params: Parameters<ProtocolMethods[K]>[0]
-		) => ReturnType<ProtocolMethods[K]>
+		handler: (params: Parameters<ProtocolMethods[K]>[0]) => ReturnType<ProtocolMethods[K]>,
 	): Disposable;
-} & Omit<LanguageClient, 'onRequest'>;;
+} & Omit<LanguageClient, "onRequest">;
 
 /**
  * Cache for cookies from REST requests to InterSystems servers.
@@ -164,7 +162,6 @@ export async function activate(context: ExtensionContext) {
 		});
 	}
 
-
 	// Resolve the ServerSpec for a document or workspace folder URI, prompting
 	// for a missing password via the Server Manager's authentication provider.
 	async function resolveServerSpec(uri: Uri) {
@@ -253,7 +250,7 @@ export async function activate(context: ExtensionContext) {
 			const newuri: Uri = objectScriptApi.serverDocumentUriForUri(Uri.parse(uri));
 			return newuri.toString();
 		}),
-		client.onRequest('intersystems/uri/forDocument', (document) => {
+		client.onRequest("intersystems/uri/forDocument", (document) => {
 			if (lte(objectScriptExt.packageJSON.version, "1.0.10")) {
 				// If the active version of vscode-objectscript doesn't expose
 				// DocumentContentProvider.getUri(), just return the empty string.
@@ -262,7 +259,7 @@ export async function activate(context: ExtensionContext) {
 			const uri: Uri | null = objectScriptApi.getUriForDocument(document);
 			return uri == null ? null : uri.toString();
 		}),
-		client.onRequest('intersystems/uri/forTypeHierarchyClasses', (classes) => {
+		client.onRequest("intersystems/uri/forTypeHierarchyClasses", (classes) => {
 			// vscode-objectscript version 1.0.11+ has been available for long enough that
 			// it's safe to assume that users have upgraded to at least 1.0.11
 			return classes.map((cls: string) => {
@@ -272,22 +269,15 @@ export async function activate(context: ExtensionContext) {
 		}),
 		client.onRequest("intersystems/server/makeRESTRequest", async (args) => {
 			// As of version 2.0.0, REST requests are made on the client side
-			return makeRESTRequest(
-				args.method,
-				args.api,
-				args.path,
-				args.server,
-				args.data,
-				args.checksum,
-				args.params,
-			).then((respdata) => {
-				if (respdata) {
-					// Can't return the entire AxiosResponse object because it's not JSON.stringify-able due to circularity
-					return { data: respdata.data };
-				}
-			});
-		},
-		),
+			return makeRESTRequest(args.method, args.api, args.path, args.server, args.data, args.checksum, args.params).then(
+				(respdata) => {
+					if (respdata) {
+						// Can't return the entire AxiosResponse object because it's not JSON.stringify-able due to circularity
+						return { data: respdata.data };
+					}
+				},
+			);
+		}),
 		client.onRequest(
 			"intersystems/uri/getText",
 			async (params: { uri: string; server: ServerSpec }): Promise<string[]> => {
@@ -302,12 +292,12 @@ export async function activate(context: ExtensionContext) {
 								: uri.path.split("/").slice(1).join(".");
 						const docParams =
 							params.server.apiVersion >= 4 &&
-								workspace
-									.getConfiguration(
-										"objectscript",
-										workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
-									)
-									.get<boolean>("multilineMethodArgs")
+							workspace
+								.getConfiguration(
+									"objectscript",
+									workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == uri.authority.toLowerCase()),
+								)
+								.get<boolean>("multilineMethodArgs")
 								? { format: "udl-multiline" }
 								: undefined;
 						const resp = await makeRESTRequest(
@@ -457,7 +447,6 @@ export async function deactivate(): Promise<void> {
 	}
 	await Promise.allSettled(promises);
 }
-
 
 // A copy of the BasicAuthorization class from ServerManager
 // We use it to patch older version of getServerSpec.

--- a/client/src/makeRESTRequest.ts
+++ b/client/src/makeRESTRequest.ts
@@ -39,16 +39,14 @@ export async function makeRESTRequest(
 		// The server doesn't support the Atelier API version required to make this request
 		client.warn(
 			"Cannot make required REST request to server " +
-			`${server.serverName !== "" ? `'${server.serverName}'` : `${server.host}:${server.port}${server.pathPrefix}`} ` +
-			`because it does not support the '${path}' endpoint, which requires Atelier API version ${api}.`,
+				`${server.serverName !== "" ? `'${server.serverName}'` : `${server.host}:${server.port}${server.pathPrefix}`} ` +
+				`because it does not support the '${path}' endpoint, which requires Atelier API version ${api}.`,
 		);
 		return undefined;
 	}
 	if (!server.credentials) {
 		// A username without a password isn't allowed
-		client.warn(
-			"Cannot make required REST request because the configured server connection is not authorized",
-		);
+		client.warn("Cannot make required REST request because the configured server connection is not authorized");
 		return undefined;
 	}
 
@@ -202,7 +200,8 @@ export async function makeRESTRequest(
 			return respdata;
 		}
 	} catch (error) {
-		const errorString = typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error);
+		const errorString =
+			typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error);
 		client.warn(`Error making REST request ${method} ${path}: ${errorString}`);
 		return undefined;
 	}

--- a/client/src/requestForwarding.ts
+++ b/client/src/requestForwarding.ts
@@ -140,7 +140,7 @@ export const requestForwardingMiddleware: Middleware = {
 };
 
 export class ISCEmbeddedContentProvider implements TextDocumentContentProvider {
-	constructor() { }
+	constructor() {}
 
 	provideTextDocumentContent(uri: Uri): ProviderResult<string> {
 		// Get the isclexer language number and position from the URI authority

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -13,7 +13,7 @@ export interface ServerSpec {
 	username: string;
 	credentials?: {
 		auth?: { username: string; password: string };
-		headers?: Record<string, string>
+		headers?: Record<string, string>;
 	};
 }
 

--- a/server/src/providers/completion.ts
+++ b/server/src/providers/completion.ts
@@ -578,8 +578,9 @@ async function completionFullClassName(
 
 	// Get all classes
 	const querydata = {
-		query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-			}`,
+		query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${
+			!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+		}`,
 		parameters: ["*.cls", 1, 1, 1, 1, 0, settings.completion.showGenerated ? 1 : 0],
 	};
 	const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -637,8 +638,9 @@ async function completionPackage(server: ServerSpec, settings: LanguageServerCon
 
 	// Get all the packages
 	const querydata = {
-		query: `SELECT DISTINCT $PIECE(dcd.Name,'.',1,$LENGTH(dcd.Name,'.')-1) AS Package FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-			}`,
+		query: `SELECT DISTINCT $PIECE(dcd.Name,'.',1,$LENGTH(dcd.Name,'.')-1) AS Package FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${
+			!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+		}`,
 		parameters: ["*.cls", 1, 1, 1, 1, 0, settings.completion.showGenerated ? 1 : 0],
 	};
 	const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -754,13 +756,13 @@ async function globalsOrRoutines(
 		server,
 		isRoutine
 			? {
-				query: `SELECT DISTINCT $PIECE(Name,'.',1,$LENGTH(Name,'.')-1) AS Name FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,1,1,1,0,'NOT (Name %PATTERN ''.E1"."0.1"G"1N1".obj"'' AND $LENGTH(Name,''.'') > 3)')`,
-				parameters: [`${prefix.length ? `${prefix.slice(0, -1)}/` : ""}*.mac,*.int,*.obj`],
-			}
+					query: `SELECT DISTINCT $PIECE(Name,'.',1,$LENGTH(Name,'.')-1) AS Name FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,1,1,1,0,'NOT (Name %PATTERN ''.E1"."0.1"G"1N1".obj"'' AND $LENGTH(Name,''.'') > 3)')`,
+					parameters: [`${prefix.length ? `${prefix.slice(0, -1)}/` : ""}*.mac,*.int,*.obj`],
+				}
 			: {
-				query: "SELECT Name FROM %SYS.GlobalQuery_NameSpaceList(,?,?,,,1,0)",
-				parameters: [`${prefix}*`, (await showInternalForServer(server)) ? 1 : 0],
-			},
+					query: "SELECT Name FROM %SYS.GlobalQuery_NameSpaceList(,?,?,,,1,0)",
+					parameters: [`${prefix}*`, (await showInternalForServer(server)) ? 1 : 0],
+				},
 	);
 	if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 		return respdata.data.result.content.map((item: { Name: string }) => {
@@ -1118,8 +1120,9 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 		// Get all appropriate subclasses of %Query
 		const querydata = {
-			query: `SELECT dcd.Name, Deprecated FROM %Dictionary.ClassDefinition_SubclassOf(?) AS sco, %Dictionary.ClassDefinition AS dcd WHERE sco.Name = dcd.Name AND sco.Name NOT %INLIST $LISTFROMSTRING(?)${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-				}`,
+			query: `SELECT dcd.Name, Deprecated FROM %Dictionary.ClassDefinition_SubclassOf(?) AS sco, %Dictionary.ClassDefinition AS dcd WHERE sco.Name = dcd.Name AND sco.Name NOT %INLIST $LISTFROMSTRING(?)${
+				!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+			}`,
 			parameters: ["%Library.Query", "%Library.ExtentSQLQuery,%Library.RowSQLQuery"],
 		};
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -1257,8 +1260,9 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 			// Get all classes that match the filter
 			const querydata = {
-				query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
-					}`,
+				query: `SELECT dcd.Name, dcd.Deprecated FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?,?) AS sod, %Dictionary.ClassDefinition AS dcd WHERE sod.Name = dcd.Name||'.cls'${
+					!settings.completion.showDeprecated ? " AND dcd.Deprecated = 0" : ""
+				}`,
 				parameters: ["*.cls", 1, 1, 1, 1, 0, settings.completion.showGenerated ? 1 : 0, `Name %STARTSWITH '${filter}'`],
 			};
 			const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -1302,10 +1306,11 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 				// Query the server to get the names and descriptions of all parameters
 				const data: QueryData = {
-					query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${membercontext.context == "instance"
-						? " AND (parent->ClassType IS NULL OR parent->ClassType != 'datatype')"
-						: ""
-						}${internalStr}${deprecatedStr}`,
+					query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${
+						membercontext.context == "instance"
+							? " AND (parent->ClassType IS NULL OR parent->ClassType != 'datatype')"
+							: ""
+					}${internalStr}${deprecatedStr}`,
 					parameters: [membercontext.baseclass],
 				};
 				const respdata = await makeRESTRequest("POST", 1, "/action/query", server, data);
@@ -1615,10 +1620,11 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 		// Query the server to get the names and descriptions of all class-specific parameters
 		const data: QueryData = {
-			query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${isProperty
-				? " OR Parent %INLIST (SELECT $LISTFROMSTRING(PropertyClass) FROM %Dictionary.CompiledClass WHERE Name = ?)"
-				: ""
-				}${!(await showInternalForServer(server)) ? " AND Internal = 0" : ""}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
+			query: `SELECT Name, Description, Origin, Type, Deprecated FROM %Dictionary.CompiledParameter WHERE Parent = ?${
+				isProperty
+					? " OR Parent %INLIST (SELECT $LISTFROMSTRING(PropertyClass) FROM %Dictionary.CompiledClass WHERE Name = ?)"
+					: ""
+			}${!(await showInternalForServer(server)) ? " AND Internal = 0" : ""}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
 			parameters: isProperty ? [normalizedcls, currentClass(doc, parsed)] : [normalizedcls],
 		};
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, data);
@@ -1933,8 +1939,9 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 						}
 					}
 					const querydata = {
-						query: `SELECT Name, Description, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ?${!(await showInternalForServer(server)) ? " AND Internal = 0" : ""
-							}`,
+						query: `SELECT Name, Description, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ?${
+							!(await showInternalForServer(server)) ? " AND Internal = 0" : ""
+						}`,
 						parameters: [thisclass],
 					};
 					const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
@@ -2377,8 +2384,9 @@ export async function onCompletion(params: CompletionParams): Promise<Completion
 
 		// Query the server to get the names and descriptions of all non-calculated properties
 		const data: QueryData = {
-			query: `SELECT Name, Description, Origin, RuntimeType, Deprecated FROM %Dictionary.CompiledProperty WHERE Parent = ? AND Calculated = 0${!showInternal ? " AND Internal = 0" : ""
-				}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
+			query: `SELECT Name, Description, Origin, RuntimeType, Deprecated FROM %Dictionary.CompiledProperty WHERE Parent = ? AND Calculated = 0${
+				!showInternal ? " AND Internal = 0" : ""
+			}${!settings.completion.showDeprecated ? " AND Deprecated = 0" : ""}`,
 			parameters: [thisclass],
 		};
 		const respdata = await makeRESTRequest("POST", 1, "/action/query", server, data);

--- a/server/src/providers/definition.ts
+++ b/server/src/providers/definition.ts
@@ -29,7 +29,7 @@ import * as ld from "../utils/languageDefinitions";
 const definitionTargetRangeMaxLines: number = 10;
 
 /** Return a `LocationLink` for class member `memberName` in class `cls`
- * 
+ *
  * This function queries `server` to find the source code of `cls` and locates
  * the definition of `memberName` within the source code.
  */
@@ -317,7 +317,7 @@ export async function onDefinition(params: TextDocumentPositionParams): Promise<
 									parsed[macrodefline][parsed[macrodefline].length - 1].p,
 									macrodefline,
 									parsed[macrodefline][parsed[macrodefline].length - 1].p +
-									parsed[macrodefline][parsed[macrodefline].length - 1].c,
+										parsed[macrodefline][parsed[macrodefline].length - 1].c,
 								),
 							),
 						)
@@ -1204,7 +1204,7 @@ export async function onDefinition(params: TextDocumentPositionParams): Promise<
 							parsed[ln][0].l == ld.cls_langindex &&
 							parsed[ln][0].s == ld.cls_keyword_attrindex &&
 							doc.getText(Range.create(ln, parsed[ln][0].p, ln, parsed[ln][0].p + parsed[ln][0].c)).toLowerCase() ==
-							"class"
+								"class"
 						) {
 							// This is the class definition line
 							let seenExtends = false,

--- a/server/src/providers/diagnostic.ts
+++ b/server/src/providers/diagnostic.ts
@@ -165,7 +165,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 							parsed[i][j].l == ld.cls_langindex &&
 							parsed[i][j].s == ld.cls_keyword_attrindex &&
 							doc.getText(Range.create(i, parsed[i][j].p, i, parsed[i][j].p + parsed[i][j].c)).toLowerCase() ==
-							"extends"
+								"extends"
 						) {
 							// The 'Extends' keyword is present
 							hassupers = true;
@@ -383,7 +383,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 					parsed[i][j - 1].l == ld.cls_langindex &&
 					parsed[i][j - 1].s == ld.cls_keyword_attrindex &&
 					doc.getText(Range.create(i, parsed[i][j - 1].p, i, parsed[i][j - 1].p + parsed[i][j - 1].c)).toLowerCase() ===
-					"class"
+						"class"
 				) {
 					// This is the class name in the class definition line
 
@@ -422,7 +422,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 								parsed[i][k].l == ld.cls_langindex &&
 								parsed[i][k].s == ld.cls_keyword_attrindex &&
 								doc.getText(Range.create(i, parsed[i][k].p, i, parsed[i][k].p + parsed[i][k].c)).toLowerCase() ==
-								"sqltablename"
+									"sqltablename"
 							) {
 								hasSqlTableName = true;
 							}
@@ -453,7 +453,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 					parsed[i][j].l == ld.cls_langindex &&
 					parsed[i][j].s == ld.cls_keyword_attrindex &&
 					doc.getText(Range.create(i, parsed[i][j].p, i, parsed[i][j].p + parsed[i][j].c)).toLowerCase() ===
-					"parameter" &&
+						"parameter" &&
 					settings.diagnostics.parameters
 				) {
 					// This line is a UDL Parameter definition
@@ -815,7 +815,8 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 							// Add this class to the map
 							addRangeToMapVal(
 								otherNsDocs,
-								`${currentNs}:::${!word.includes(".") && word.startsWith("%") ? `%Library.${word.slice(1)}` : word
+								`${currentNs}:::${
+									!word.includes(".") && word.startsWith("%") ? `%Library.${word.slice(1)}` : word
 								}.cls`,
 								wordrange,
 							);
@@ -1223,7 +1224,7 @@ export async function onDiagnostics(params: DocumentDiagnosticParams): Promise<D
 								parsed[ln][k].l == ld.cls_langindex &&
 								parsed[ln][k].s == ld.cls_keyword_attrindex &&
 								doc.getText(Range.create(ln, parsed[ln][k].p, ln, parsed[ln][k].p + parsed[ln][k].c)).toLowerCase() ==
-								"sqlfieldname"
+									"sqlfieldname"
 							) {
 								hasSqlFieldName = true;
 							} else if (

--- a/server/src/providers/documentSymbol.ts
+++ b/server/src/providers/documentSymbol.ts
@@ -117,7 +117,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 						0,
 						lastnonempty,
 						parsed[lastnonempty][parsed[lastnonempty].length - 1].p +
-						parsed[lastnonempty][parsed[lastnonempty].length - 1].c,
+							parsed[lastnonempty][parsed[lastnonempty].length - 1].c,
 					);
 
 					// Determine if this class is Deprecated
@@ -181,7 +181,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 							0,
 							lastNonEmpty,
 							parsed[lastNonEmpty][parsed[lastNonEmpty].length - 1].p +
-							parsed[lastNonEmpty][parsed[lastNonEmpty].length - 1].c,
+								parsed[lastNonEmpty][parsed[lastNonEmpty].length - 1].c,
 						),
 						selectionRange: Range.create(line, parsed[line][1].p, line, parsed[line][1].p + parsed[line][1].c),
 						tags: deprecated ? [SymbolTag.Deprecated] : undefined,
@@ -416,7 +416,7 @@ export async function onDocumentSymbol(params: DocumentSymbolParams) {
 					parsed[line][tkn + 1].l == ld.html_langindex &&
 					parsed[line][tkn + 1].s == ld.html_tag_attrindex &&
 					doc.getText(Range.create(line, parsed[line][tkn].p, line, parsed[line][tkn].p + parsed[line][tkn].c)) ===
-					"<" &&
+						"<" &&
 					doc
 						.getText(
 							Range.create(line, parsed[line][tkn + 1].p, line, parsed[line][tkn + 1].p + parsed[line][tkn + 1].c),

--- a/server/src/providers/foldingRange.ts
+++ b/server/src/providers/foldingRange.ts
@@ -736,7 +736,7 @@ export async function onFoldingRanges(params: FoldingRangeParams) {
 					parsed[line][tkn + 1].l == ld.html_langindex &&
 					parsed[line][tkn + 1].s == ld.html_tag_attrindex &&
 					doc.getText(Range.create(line, parsed[line][tkn].p, line, parsed[line][tkn].p + parsed[line][tkn].c)) ===
-					"<" &&
+						"<" &&
 					doc
 						.getText(
 							Range.create(line, parsed[line][tkn + 1].p, line, parsed[line][tkn + 1].p + parsed[line][tkn + 1].c),

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -138,7 +138,7 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 					parsed[params.position.line][i].s == ld.cos_macro_attrindex) ||
 				(parsed[params.position.line][i].l == ld.sql_langindex &&
 					parsed[params.position.line][i].s == ld.sql_iden_attrindex &&
-					doc.getText(Range.create(params.position.line, symbolstart, params.position.line, symbolstart + 3)) == "$$")
+					doc.getText(Range.create(params.position.line, symbolstart, params.position.line, symbolstart + 3)) == "$$$")
 			) {
 				// This is a macro
 
@@ -157,7 +157,7 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 					macrotext = macrotext.slice(0, parenIdx);
 					macrorange.end = Position.create(params.position.line, symbolstart + macrotext.length);
 				}
-				if (macrotext.slice(0, 3) == "$$") {
+				if (macrotext.startsWith("$$$")) {
 					macrotext = macrotext.slice(3);
 				}
 
@@ -171,7 +171,7 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 							macrorange.end.character,
 							params.position.line,
 							parsed[params.position.line][parsed[params.position.line].length - 1].p +
-							parsed[params.position.line][parsed[params.position.line].length - 1].c,
+								parsed[params.position.line][parsed[params.position.line].length - 1].c,
 						),
 					);
 
@@ -472,14 +472,15 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 							value: ["$ZUTIL", "$ZU"].includes(sysftext)
 								? markupValue(`[Online documentation](${sysfdoc.link})`)
 								: markupValue(
-									sysfdoc.documentation.join(""),
-									sysfdoc.link
-										? `[Online documentation](${sysfdoc.link[0] == "h"
-											? sysfdoc.link
-											: `https://docs.intersystems.com/irislatest/csp/docbook/Doc.View.cls?KEY=RCOS_${sysfdoc.link}`
-										})`
-										: "",
-								),
+										sysfdoc.documentation.join(""),
+										sysfdoc.link
+											? `[Online documentation](${
+													sysfdoc.link[0] == "h"
+														? sysfdoc.link
+														: `https://docs.intersystems.com/irislatest/csp/docbook/Doc.View.cls?KEY=RCOS_${sysfdoc.link}`
+												})`
+											: "",
+									),
 						},
 						range: sysfrange,
 					};
@@ -1245,8 +1246,9 @@ export async function onHover(params: TextDocumentPositionParams): Promise<Hover
 						if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 							// We got data back
 
-							const header = `(**${normalizedcls}**) <u>**${param}**</u>${respdata.data.result.content[0].Type != "" ? ` As **${respdata.data.result.content[0].Type}**` : ""
-								}`;
+							const header = `(**${normalizedcls}**) <u>**${param}**</u>${
+								respdata.data.result.content[0].Type != "" ? ` As **${respdata.data.result.content[0].Type}**` : ""
+							}`;
 							return {
 								contents: {
 									kind: MarkupKind.Markdown,

--- a/server/src/providers/signatureHelp.ts
+++ b/server/src/providers/signatureHelp.ts
@@ -198,7 +198,7 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 		triggerlang != ld.cos_langindex ||
 		// Don't compute signature help inside of a string literal
 		(doc.getText(Range.create(Position.create(params.position.line, 0), params.position)).split('"').length - 1) % 2 ==
-		1
+			1
 	) {
 		if (params.context.activeSignatureHelp) {
 			params.context.activeSignatureHelp.signatures[0].documentation = signatureHelpDocumentationCache!.doc;
@@ -365,16 +365,16 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 			const querydata =
 				member == "%New"
 					? {
-						// Get the information for both %New and %OnNew
-						query:
-							"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-						parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
-					}
+							// Get the information for both %New and %OnNew
+							query:
+								"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
+							parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
+						}
 					: {
-						query:
-							"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-						parameters: [membercontext.baseclass, unquotedname],
-					};
+							query:
+								"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
+							parameters: [membercontext.baseclass, unquotedname],
+						};
 			const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 			if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 				// We got data back
@@ -613,16 +613,16 @@ export async function onSignatureHelp(params: SignatureHelpParams): Promise<Sign
 				const querydata =
 					member == "%New"
 						? {
-							// Get the information for both %New and %OnNew
-							query:
-								"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-							parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
-						}
+								// Get the information for both %New and %OnNew
+								query:
+									"SELECT FormalSpec, ReturnType, Description, Stub, Origin FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
+								parameters: [membercontext.baseclass, unquotedname, "%OnNew"],
+							}
 						: {
-							query:
-								"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-							parameters: [membercontext.baseclass, unquotedname],
-						};
+								query:
+									"SELECT FormalSpec, ReturnType, Description, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
+								parameters: [membercontext.baseclass, unquotedname],
+							};
 				const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 				if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 					// We got data back

--- a/server/src/utils/functions.ts
+++ b/server/src/utils/functions.ts
@@ -324,7 +324,7 @@ export function getMacroContext(doc: TextDocument, parsed: compressedline[], lin
 							parsed[i][j].l == ld.cls_langindex &&
 							parsed[i][j].s == ld.cls_keyword_attrindex &&
 							doc.getText(Range.create(i, parsed[i][j].p, i, parsed[i][j].p + parsed[i][j].c)).toLowerCase() ==
-							"extends"
+								"extends"
 						) {
 							seenextends = true;
 						} else {
@@ -1182,7 +1182,7 @@ export async function getClassMemberContext(
 
 		result.context = "instance";
 		switch (
-		doc.getText(Range.create(line, parsed[line][dot - 1].p, line, parsed[line][dot - 1].p + parsed[line][dot - 1].c))
+			doc.getText(Range.create(line, parsed[line][dot - 1].p, line, parsed[line][dot - 1].p + parsed[line][dot - 1].c))
 		) {
 			case "}":
 				result.baseclass = "%Library.DynamicObject";
@@ -1972,7 +1972,7 @@ async function parseSetCommand(
 					(parsed[ln][tkn + 1].s == ld.cos_objdot_attrindex ||
 						(parsed[ln][tkn + 1].s == ld.cos_delim_attrindex &&
 							doc.getText(Range.create(ln, parsed[ln][tkn + 1].p, ln, parsed[ln][tkn + 1].p + parsed[ln][tkn + 1].c)) ==
-							"("))
+								"("))
 				) &&
 				// Variable isn't preceded by the indirection operator
 				!(tkn - 1 >= 0 && parsed[ln][tkn - 1].l == ld.cos_langindex && parsed[ln][tkn - 1].s == ld.cos_indir_attrindex)
@@ -2244,14 +2244,14 @@ async function parseSetCommand(
 			const nextTkn = nextToken(parsed, exprLn, exprTkn);
 			if (parsed[exprLn][exprTkn].s == ld.cos_jsonb_attrindex) {
 				switch (
-				doc.getText(
-					Range.create(
-						exprLn,
-						parsed[exprLn][exprTkn].p,
-						exprLn,
-						parsed[exprLn][exprTkn].p + parsed[exprLn][exprTkn].c,
-					),
-				)
+					doc.getText(
+						Range.create(
+							exprLn,
+							parsed[exprLn][exprTkn].p,
+							exprLn,
+							parsed[exprLn][exprTkn].p + parsed[exprLn][exprTkn].c,
+						),
+					)
 				) {
 					case "{":
 						result = "%Library.DynamicObject";
@@ -2478,16 +2478,16 @@ async function determineUndeclaredLocalVarClass(
 								const querydata =
 									member == "%New"
 										? {
-											// Get the information for both %New and %OnNew
-											query:
-												"SELECT FormalSpec, $LISTGET($LISTGET(FormalSpecParsed,?),2) AS Type, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
-											parameters: [argNum, membercontext.baseclass, unquotedname, "%OnNew"],
-										}
+												// Get the information for both %New and %OnNew
+												query:
+													"SELECT FormalSpec, $LISTGET($LISTGET(FormalSpecParsed,?),2) AS Type, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND (Name = ? OR Name = ?)",
+												parameters: [argNum, membercontext.baseclass, unquotedname, "%OnNew"],
+											}
 										: {
-											query:
-												"SELECT FormalSpec, $LISTGET($LISTGET(FormalSpecParsed,?),2) AS Type, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
-											parameters: [argNum, membercontext.baseclass, unquotedname],
-										};
+												query:
+													"SELECT FormalSpec, $LISTGET($LISTGET(FormalSpecParsed,?),2) AS Type, Stub FROM %Dictionary.CompiledMethod WHERE Parent = ? AND Name = ?",
+												parameters: [argNum, membercontext.baseclass, unquotedname],
+											};
 								const respdata = await makeRESTRequest("POST", 1, "/action/query", server, querydata);
 								if (Array.isArray(respdata?.data?.result?.content) && respdata.data.result.content.length > 0) {
 									// We got data back
@@ -3192,9 +3192,9 @@ export async function determineVariableClass(
 	const varText = doc.getText(
 		parsed[line][tkn].s == ld.cos_macro_attrindex
 			? // Can't use findFullRange() on a macro token because it will capture
-			// everything, including the trailing dot that triggered the completion.
-			// A macro token should only occur here for completion requests.
-			Range.create(line, parsed[line][tkn].p, line, parsed[line][tkn].p + parsed[line][tkn].c)
+				// everything, including the trailing dot that triggered the completion.
+				// A macro token should only occur here for completion requests.
+				Range.create(line, parsed[line][tkn].p, line, parsed[line][tkn].p + parsed[line][tkn].c)
 			: findFullRange(line, parsed, tkn, parsed[line][tkn].p, parsed[line][tkn].p + parsed[line][tkn].c),
 	);
 	if ([ld.cos_param_attrindex, ld.cos_macro_attrindex].includes(parsed[line][tkn].s)) {

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -109,7 +109,7 @@ export type KeywordDoc = {
 	constraint?: string | string[];
 };
 
-export type { ServerSpec } from '../../../common/out/types';
+export type { ServerSpec } from "../../../common/out/types";
 
 /**
  * Context of the method/routine that a macro is in, including extra information needed for macro expansion.


### PR DESCRIPTION
A couple of `"$$$"` string literals were incorrectly changed to `"$$"` when you added linting. I fixed that issue and then ran `npm run lint-fix` to verify that they weren't changed.